### PR TITLE
Use OSM basemap to avoid AGOL sign-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@ This file is a shared memory for all agents working in this repository.
 
 - 2025-11-22: Refined batch geocoder UI with status messaging, input validation, and export button handling.
 - 2025-12-12: Added user-supplied AGOL API key workflow with local storage, modal prompt, and gear settings panel.
+- 2026-01-15: Switched default basemap to OSM to avoid AGOL sign-in prompts.

--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
       esriConfig.apiKey = currentApiKey;
 
       const map = new Map({
-        basemap: "arcgis-light-gray",
+        basemap: "osm",
       });
 
       const view = new MapView({


### PR DESCRIPTION
## Summary
- switch the default map basemap to OpenStreetMap so the app no longer prompts for AGOL sign-in
- update agent change log to record the basemap change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f19c867f483279993f3941adea7f9)